### PR TITLE
Fix: Explicitly specifying python2 pip in install dependencies script.

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -14,16 +14,16 @@ fi
 
 # Python Dependencies
 if roscd skiros2; then
-    cd .. && pip install -r requirements.txt --user
+    cd .. && python -m pip install -r requirements.txt --user
 fi
 if roscd skills_sandbox; then
-    pip install -r requirements.txt --user
+    python -m pip install -r requirements.txt --user
 fi
 if roscd vision; then
-    pip install -r requirements.txt --user
+    python -m pip install -r requirements.txt --user
 fi
 if roscd low_level_logics; then
-    pip install -r requirements.txt --user
+    python -m pip install -r requirements.txt --user
 fi
 
 # Install realsense drivers


### PR DESCRIPTION
We had issues enforcing python2 for pip.

This branch can be deleted after the merge.